### PR TITLE
IGBF-1850 htsjdk-igb is importing packages from the same library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,17 @@ buildscript {
     repositories {
         mavenCentral()
     }
+	dependencies {
+		classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:4.2.0'
+  }
 }
 
 plugins {
     id 'java'
     id 'maven'
-    id 'osgi'
-
 }
+
+apply plugin: 'biz.aQute.bnd.builder'
 
 repositories {
     mavenCentral()
@@ -33,15 +36,14 @@ logger.info("build for version:" + version)
 defaultTasks 'jar'
 
 jar {
-  archiveName = 'htsjdk-igb-'+version+".jar"
-
-  manifest { // the manifest of the default jar is of type OsgiManifest
-      name = 'htsjdk for IGB'
-      instruction 'Bundle-Vendor', 'Loraine Lab'
-      instruction 'Bundle-Description', 'htsjdk for IGB'
-      instruction 'Bundle-DocURL', 'https://github.com/lorainelab/htsjdk'
-
-      }
+archiveName = 'htsjdk-igb-'+version+".jar"
+    bnd ('Bundle-Name': 'htsjdk for IGB',
+         'Bundle-Vendor': 'Loraine Lab',
+         'Bundle-Description': 'htsjdk for IGB',
+         'Bundle-DocURL': 'https://github.com/lorainelab/htsjdk',
+         'Export-Package': 'htsjdk.*',
+         'Import-Package': '!htsjdk.*,org.apache.commons.*',
+         )
 }
 
 wrapper {


### PR DESCRIPTION
1. Remove 'osgi' plugin and use 'biz.aQute.bnd.builder'. 
2. Don't import htsjdk-igb packages